### PR TITLE
1.4.1: Fix stronghold cache

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ org.gradle.jvmargs = -Xmx2G
 org.gradle.parallel = true
 org.gradle.caching = true
 
-mod_version = 1.4.0
+mod_version = 1.4.1
 target_version = 1.16.1
 archives_name = chunkcacher
 maven_group = me.char321

--- a/src/main/java/me/char321/chunkcacher/mixin/ChunkGeneratorMixin.java
+++ b/src/main/java/me/char321/chunkcacher/mixin/ChunkGeneratorMixin.java
@@ -3,6 +3,7 @@ package me.char321.chunkcacher.mixin;
 import me.char321.chunkcacher.WorldCache;
 import net.minecraft.util.math.ChunkPos;
 import net.minecraft.world.gen.chunk.ChunkGenerator;
+import net.minecraft.world.gen.chunk.StructuresConfig;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -17,18 +18,26 @@ import java.util.List;
 @Mixin(ChunkGenerator.class)
 public class ChunkGeneratorMixin {
 
-    @Shadow @Final private List<ChunkPos> strongholdPositions;
+    @Shadow
+    @Final
+    private List<ChunkPos> strongholdPositions;
+
+    @Shadow
+    @Final
+    private StructuresConfig structuresConfig;
 
     @Inject(method = "generateStrongholdPositions", at = @At("HEAD"))
     private void applyCachedStrongholds(CallbackInfo ci) {
-        if (WorldCache.shouldCache() && WorldCache.strongholdCache != null && this.strongholdPositions.isEmpty()) {
+        // this.structuresConfig.getStronghold() == StructuresConfig.DEFAULT_STRONGHOLD works for vanilla world generation because only the overworld will use DEFAULT_STRONGHOLD,
+        // but it may fail with datapacks, mods or 20w14∞ adding new dimensions
+        if (WorldCache.shouldCache() && this.structuresConfig.getStronghold() == StructuresConfig.DEFAULT_STRONGHOLD && WorldCache.strongholdCache != null && this.strongholdPositions.isEmpty()) {
             this.strongholdPositions.addAll(WorldCache.strongholdCache);
         }
     }
 
     @Inject(method = "generateStrongholdPositions", at = @At("TAIL"))
     private void cacheStrongholds(CallbackInfo ci) {
-        if (WorldCache.shouldCache() && WorldCache.strongholdCache == null) {
+        if (WorldCache.shouldCache() && this.structuresConfig.getStronghold() == StructuresConfig.DEFAULT_STRONGHOLD && WorldCache.strongholdCache == null) {
             WorldCache.strongholdCache = Collections.unmodifiableList(new ArrayList<>(this.strongholdPositions));
         }
     }


### PR DESCRIPTION
`this.structuresConfig.getStronghold() == StructuresConfig.DEFAULT_STRONGHOLD` works for vanilla world generation because only the overworld will use `DEFAULT_STRONGHOLD`.
It will probably fail with datapacks, mods or 20w14∞ adding new dimensions.